### PR TITLE
Add minikube context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     tini \
     sudo \
+    vim \
     bash-completion \
     docker.io \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -99,6 +100,9 @@ COPY --from=client-builder /client/dist /ui
 # Copy the script to automate the krs health command to the container
 COPY automateKrsHealth.sh /sbin/
 RUN chmod +x /sbin/automateKrsHealth.sh
+
+COPY fix-kubeconfig.sh /root/
+RUN chmod +x /root/fix-kubeconfig.sh
 
 # Expose port for ttyd (for interactive terminal)
 EXPOSE 57681

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-extension: build-extension ## Install the extension
 update-extension: build-extension ## Update the extension
 	docker extension update $(IMAGE):$(TAG)
 
-debug-extension: build-extension## Debug extension
+debug-extension: ## Debug extension
 	docker extension dev debug $(IMAGE):$(TAG)
 
 reset-extension: ## Turn off debug mode

--- a/fix-kubeconfig.sh
+++ b/fix-kubeconfig.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+MINIKUBE_IP=$1
+
+# Copy kubeconfig to a new file inside the container (so the local file is not modified)
+cp /root/.kube/config /root/.kube/config_copy
+
+# Find all unique local paths before .minikube and store them in a variable
+LOCAL_PATHS=$(grep -oP '/[^ ]+(?=/.minikube)' /root/.kube/config_copy | sort -u)
+
+if [ -n "$LOCAL_PATHS" ]; then
+  echo "Detected local paths:"
+  echo "$LOCAL_PATHS"
+
+  # Loop through each detected path and replace it with /root in the copied kubeconfig
+  echo "$LOCAL_PATHS" | while read -r LOCAL_PATH; do
+    if [ -n "$LOCAL_PATH" ]; then
+      echo "Replacing path: $LOCAL_PATH with /root"
+
+      # Replace the paths in the copied kubeconfig file
+      sed "s|$LOCAL_PATH|/root|g" /root/.kube/config_copy > /tmp/kubeconfig.tmp && cp /tmp/kubeconfig.tmp /root/.kube/config_copy
+    fi
+  done
+
+  echo "Kubeconfig paths have been updated in config_copy."
+else
+  echo "No local paths found to replace."
+fi
+
+# Replace the server IP address in the copied kubeconfig with the Minikube IP
+# if (current line contains 'server') then
+#    # Look at the next line
+#    if (next line contains 'name: minikube') then
+#        # If both conditions are true, replace the 'server' line with the new Minikube IP
+#        replace 'server' line with "https://$MINIKUBE_IP:6443"
+#   end if
+# end if
+
+# sed -i: it directly modifies the file
+sed -i '/provider: minikube.sigs.k8s.io/{N;N;N; s|server: https://.*|server: https://'$MINIKUBE_IP':8443|g}' /root/.kube/config_copy
+
+echo "Minikube IP ($MINIKUBE_IP) has been updated in config_copy."


### PR DESCRIPTION
# Description
In this version, the krs-docker-extension has been updated to use the Minikube context to scan the clusters. Developers will be able to switch to different environments such as Docker Desktop and Minikube. 

# How it looks like
- fix-kubeconfig.sh: This is a script for updating Kubernetes Configuration for Minikube setup. 
- krs-helpers: Add some new functions for checking the current context whether it's Docker-Desktop or Minikube context and getting the Minikube IP.